### PR TITLE
Changes in int casting

### DIFF
--- a/ext/ruby_binlog_row_event.cpp
+++ b/ext/ruby_binlog_row_event.cpp
@@ -237,7 +237,7 @@ void RowEvent::proc0(mysql::Row_of_fields &fields, VALUE rb_fields) {
         break;
 
       case mysql::system::MYSQL_TYPE_SHORT:
-        rval = UINT2NUM(itor->as_int16());
+        rval = UINT2NUM((boost::uint16_t)(itor->as_int16()));
         break;
 
       case mysql::system::MYSQL_TYPE_INT24: {
@@ -250,11 +250,11 @@ void RowEvent::proc0(mysql::Row_of_fields &fields, VALUE rb_fields) {
       } break;
 
       case mysql::system::MYSQL_TYPE_LONG:
-        rval = UINT2NUM(itor->as_int32());
+        rval = INT2NUM(itor->as_int32());
         break;
 
       case mysql::system::MYSQL_TYPE_LONGLONG:
-        rval = ULL2NUM(itor->as_int64());
+        rval = LL2NUM(itor->as_int64());
         break;
 
       case mysql::system::MYSQL_TYPE_BIT: {


### PR DESCRIPTION
Cast mysql short ints to unsigned ints before converting them to
unsigned ints in ruby. This can come back and bite us if we use signed
short ints.

Always cast MYSQL_TYPE_LONG to signed 32 bit ints.

Always cast MYSQL_TYPE_LONGLONG to signed 64 bit ints.
